### PR TITLE
Feature tpapi

### DIFF
--- a/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
@@ -239,6 +239,13 @@ public abstract class ComponentSolver : ICommandResponder
     }
     
     #region Protected Properties
+
+    protected string StrikeMessage
+    {
+        get;
+        set;
+    }
+
     protected bool Solved
     {
         get

--- a/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
@@ -98,7 +98,6 @@ public abstract class ComponentSolver : ICommandResponder
         while (subcoroutine.MoveNext())
         {
             object currentValue = subcoroutine.Current;
-            int temp;
             if (currentValue is string)
             {
                 string currentString = (string)currentValue;
@@ -141,12 +140,15 @@ public abstract class ComponentSolver : ICommandResponder
                 {
                     DisableOnStrike = true;
                 }
-                else if (currentString.StartsWith("award strikes ", StringComparison.CurrentCultureIgnoreCase) &&
-                         int.TryParse(currentString.Substring(14), out temp))
+                else if (currentString.StartsWith("award strikes ", StringComparison.CurrentCultureIgnoreCase))
                 {
-                    _strikeCount += temp;
-                    AwardStrikes(_currentUserNickName, _currentResponseNotifier, temp);
-                    DisableOnStrike = false;
+                    int awardStrikeCount;
+                    if (int.TryParse(currentString.Substring(14), out awardStrikeCount))
+                    {
+                        _strikeCount += awardStrikeCount;
+                        AwardStrikes(_currentUserNickName, _currentResponseNotifier, awardStrikeCount);
+                        DisableOnStrike = false;
+                    }
                 }
             }
             else if (currentValue is Quaternion)

--- a/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
@@ -123,8 +123,7 @@ public abstract class ComponentSolver : ICommandResponder
                          int.TryParse(currentString.Substring(14), out temp))
                 {
                     _strikeCount += temp;
-                    AwardStrikes(_currentUserNickName, _currentResponseNotifier, StrikeCount - previousStrikeCount);
-                    previousStrikeCount = StrikeCount;
+                    AwardStrikes(_currentUserNickName, _currentResponseNotifier, temp);
                     DisableOnStrike = false;
                 }
             }

--- a/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/ComponentSolver.cs
@@ -115,7 +115,7 @@ public abstract class ComponentSolver : ICommandResponder
                 {
                     OnStrike(null);
                 }
-                else if (currentString.Equals("disablestriketracker", StringComparison.InvariantCultureIgnoreCase))
+                else if (currentString.Equals("multiple strikes", StringComparison.InvariantCultureIgnoreCase))
                 {
                     DisableOnStrike = true;
                 }

--- a/Assets/Scripts/ComponentSolvers/Helpers/ComponentSolverFactory.cs
+++ b/Assets/Scripts/ComponentSolvers/Helpers/ComponentSolverFactory.cs
@@ -32,6 +32,7 @@ public static class ComponentSolverFactory
         ModComponentSolverCreators["ButtonV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new SquareButtonComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
         ModComponentSolverCreators["SimonV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new SimonStatesComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
         ModComponentSolverCreators["PasswordV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new SafetySafeComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
+        ModComponentSolverCreators["MorseV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new MorsematicsComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
         ModComponentSolverCreators["NeedyVentV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new NeedyQuizComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
 		ModComponentSolverCreators["NeedyKnobV2"] = (bombCommander, bombComponent, ircConnection, canceller) => new NeedyRotaryPhoneComponentSolver(bombCommander, bombComponent, ircConnection, canceller);
 

--- a/Assets/Scripts/ComponentSolvers/Modded/External/CoroutineModComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/External/CoroutineModComponentSolver.cs
@@ -87,10 +87,9 @@ public class CoroutineModComponentSolver : ComponentSolver
                     DoInteractionStart(selectable);
                     yield return new WaitForSeconds(0.1f);
                     DoInteractionEnd(selectable);
-                    if (beforeStrikeCount != StrikeCount || Canceller.ShouldCancel)
+                    if (beforeStrikeCount != StrikeCount || Canceller.ShouldCancel || Solved)
                         break;
                 }
-
             }
             if (currentObject is string)
             {
@@ -102,6 +101,13 @@ public class CoroutineModComponentSolver : ComponentSolver
                 }
             }
             yield return currentObject;
+
+            if (Solved)
+            {
+                Debug.LogWarningFormat("The Module was solved possibly early by a submitted command to the invokation of {0}.{1}; Command invokation is being aborted to prevent strikes.", ProcessMethod.DeclaringType.FullName, ProcessMethod.Name);
+                Debug.LogWarning(inputCommand);
+                break;
+            }
 
             if (StrikeCount != beforeStrikeCount)
             {

--- a/Assets/Scripts/ComponentSolvers/Modded/External/CoroutineModComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/External/CoroutineModComponentSolver.cs
@@ -60,6 +60,7 @@ public class CoroutineModComponentSolver : ComponentSolver
             yield break;
         }
 
+        int beforeStrikeCount = StrikeCount;
         while (true)
         {
             object currentObject = responseCoroutine.Current;
@@ -79,7 +80,6 @@ public class CoroutineModComponentSolver : ComponentSolver
             }
             if (currentObject is KMSelectable[])
             {
-                int beforeStrikeCount = StrikeCount;
                 KMSelectable[] selectables = (KMSelectable[]) currentObject;
                 foreach (KMSelectable selectable in selectables)
                 {
@@ -117,6 +117,13 @@ public class CoroutineModComponentSolver : ComponentSolver
 
             if (Canceller.ShouldCancel)
                 TryCancel = true;
+
+            if (StrikeCount != beforeStrikeCount)
+            {
+                Debug.LogWarningFormat("A Strike was caused by a submitted command to the invokation of {0}.{1}; Command invokation is being aborted.", ProcessMethod.DeclaringType.FullName, ProcessMethod.Name);
+                Debug.LogWarning(inputCommand);
+                break;
+            }
         }        
     }
 

--- a/Assets/Scripts/ComponentSolvers/Modded/External/SimpleModComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/External/SimpleModComponentSolver.cs
@@ -54,6 +54,7 @@ public class SimpleModComponentSolver : ComponentSolver
             if (selectable == null)
             {
                 Debug.LogErrorFormat("An empty selectable has been found at index {0} within the selectable array returned from {1}.{2}; Skipping this index, however this may have unintended sideeffects.", selectableIndex, ProcessMethod.DeclaringType.FullName, ProcessMethod.Name);
+                yield return new WaitForSeconds(0.1f);
                 continue;
             }
 
@@ -61,8 +62,9 @@ public class SimpleModComponentSolver : ComponentSolver
             yield return new WaitForSeconds(0.1f);
             DoInteractionEnd(selectable);
 
-            //Escape the sequence if a part of the given sequence is wrong
-            if (StrikeCount != beforeInteractionStrikeCount)
+            //Escape the sequence if a part of the given sequence is wrong, or if part of the sequence solved the module.
+            //This means it is no longer possible to death warp a bomb in twitch plays. Kappa Keepo
+            if (StrikeCount != beforeInteractionStrikeCount || Solved)
             {
                 yield break;
             }

--- a/Assets/Scripts/ComponentSolvers/Modded/External/SimpleModComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/External/SimpleModComponentSolver.cs
@@ -26,7 +26,7 @@ public class SimpleModComponentSolver : ComponentSolver
         try
         {
             selectableSequence = (KMSelectable[])ProcessMethod.Invoke(CommandComponent, new object[] { inputCommand });
-            if (selectableSequence == null)
+            if (selectableSequence == null || selectableSequence.Length == 0)
             {
                 yield break;
             }
@@ -37,7 +37,7 @@ public class SimpleModComponentSolver : ComponentSolver
             Debug.LogException(ex);
             yield break;
         }
-
+        
         yield return "modsequence";
 
         int beforeInteractionStrikeCount = StrikeCount;
@@ -53,7 +53,6 @@ public class SimpleModComponentSolver : ComponentSolver
             KMSelectable selectable = selectableSequence[selectableIndex];
             if (selectable == null)
             {
-                Debug.LogErrorFormat("An empty selectable has been found at index {0} within the selectable array returned from {1}.{2}; Skipping this index, however this may have unintended sideeffects.", selectableIndex, ProcessMethod.DeclaringType.FullName, ProcessMethod.Name);
                 yield return new WaitForSeconds(0.1f);
                 continue;
             }

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/ForgetMeNotComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/ForgetMeNotComponentSolver.cs
@@ -42,7 +42,7 @@ public class ForgetMeNotComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     yield break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/MorsematicsComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/MorsematicsComponentSolver.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class MorsematicsComponentSolver : ComponentSolver
+{
+    public MorsematicsComponentSolver(BombCommander bombCommander, MonoBehaviour bombComponent, IRCConnection ircConnection, CoroutineCanceller canceller) :
+        base(bombCommander, bombComponent, ircConnection, canceller)
+    {
+        _component = bombComponent.GetComponent(_componentType);
+        _transmit = (KMSelectable)_transmitField.GetValue(_component);
+        _switch = (KMSelectable)_switchField.GetValue(_component);
+        helpMessage = "Turn the lights off with !{0} lights off. Turn the lights on with !{0} lights on. Tranmit the answer with !{0} transmit -..-";
+    }
+
+    protected override IEnumerator RespondToCommandInternal(string inputCommand)
+    {
+        if ((_lightsOn && inputCommand.Equals("lights off", StringComparison.InvariantCultureIgnoreCase)) || 
+            (!_lightsOn && inputCommand.Equals("lights on", StringComparison.InvariantCultureIgnoreCase)))
+        {
+            yield return inputCommand;
+            _lightsOn = !_lightsOn;
+            DoInteractionStart(_switch);
+            yield return new WaitForSeconds(0.1f);
+            DoInteractionEnd(_switch);
+            yield break;
+        }
+        var letter = Regex.Match(inputCommand, "^((transmit|xmit|trans|tx) )([.-]+)$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        if (letter.Success)
+        {
+            yield return inputCommand;
+            yield return "strike";
+            yield return "solve";
+            foreach (var tx in letter.Groups[3].ToString())
+            {
+                DoInteractionStart(_transmit);
+                yield return tx == '.'
+                    ? new WaitForSeconds(0.08f)
+                    : new WaitForSeconds(0.32f);
+                DoInteractionEnd(_transmit);
+                yield return new WaitForSeconds(0.08f);
+            }
+        }
+    }
+
+    static MorsematicsComponentSolver()
+    {
+        _componentType = ReflectionHelper.FindType("AdvancedMorse");
+        _transmitField = _componentType.GetField("ButtonTransmit", BindingFlags.Public | BindingFlags.Instance);
+        _switchField = _componentType.GetField("ButtonSwitch", BindingFlags.Public | BindingFlags.Instance);
+    }
+
+    private Component _component = null;
+    private static Type _componentType = null;
+    private static FieldInfo _switchField = null;
+    private static FieldInfo _transmitField = null;
+   
+
+
+    private bool _lightsOn = true;
+    private KMSelectable _switch = null;
+    private KMSelectable _transmit = null;
+}

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/MorsematicsComponentSolver.cs.meta
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/MorsematicsComponentSolver.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0f53c7fc63c22344c8f060ec968c23b2
+timeCreated: 1496814398
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/NeedyQuizComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/NeedyQuizComponentSolver.cs
@@ -35,6 +35,7 @@ public class NeedyQuizComponentSolver : ComponentSolver
                 Debug.Log("[Answering Questions #" + _thisLoggingID + "] ABORT! ABORT!!! ABOOOOOOORT!!!!!");
                 yield return "sendtochat ABORT! ABORT!!! ABOOOOOOORT!!!!!";
                 int strikeCount = 0;
+                yield return "multiple strikes";
                 while (!Detonated)
                 {
                     strikeCount++;

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/NeedyQuizComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/NeedyQuizComponentSolver.cs
@@ -34,13 +34,13 @@ public class NeedyQuizComponentSolver : ComponentSolver
                 Debug.Log("[Answering Questions #" + _thisLoggingID + "] Given answer: Y");
                 Debug.Log("[Answering Questions #" + _thisLoggingID + "] ABORT! ABORT!!! ABOOOOOOORT!!!!!");
                 yield return "sendtochat ABORT! ABORT!!! ABOOOOOOORT!!!!!";
-
+                int strikeCount = 0;
                 while (!Detonated)
                 {
-                    yield return "add strike";
+                    strikeCount++;
                     _service.CauseStrike("ABORT!");
                 }
-                yield return "award strikes";
+                yield return "award strikes " + strikeCount;
                 yield break;
             }
 

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/RoundKeypadComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/RoundKeypadComponentSolver.cs
@@ -44,7 +44,7 @@ public class RoundKeypadComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     yield break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/SafetySafeComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/SafetySafeComponentSolver.cs
@@ -24,7 +24,7 @@ public class SafetySafeComponentSolver : ComponentSolver
         _buttons = (MonoBehaviour[])_buttonsField.GetValue(bombComponent.GetComponent(_componentType));
         _lever = (MonoBehaviour)_leverField.GetValue(bombComponent.GetComponent(_componentType));
 
-        helpMessage = "Listen to the dials with !{0} cycle. Make a correction to a single dial with !{0} BM 3. Enter the solution with !{0} 6 0 6 8 2 5. Submit the answer with !{0} submit. Dial positions are TL, TM, TR, BL, BM, BR.";
+        helpMessage = "Listen to the dials with !{0} cycle. Listen to a single dial with !{0} cycle BR. Make a correction to a single dial with !{0} BM 3. Enter the solution with !{0} 6 0 6 8 2 5. Submit the answer with !{0} submit. Dial positions are TL, TM, TR, BL, BM, BR.";
     }
 
     protected override IEnumerator RespondToCommandInternal(string inputCommand)
@@ -39,14 +39,32 @@ public class SafetySafeComponentSolver : ComponentSolver
             yield return new WaitForSeconds(0.1f);
             DoInteractionEnd(_lever);
         }
-        else if (split[0] == "cycle" && split.Length == 1)
+        else if (split[0] == "cycle" && split.Length <= 2)
         {
             yield return "cycle";
-            for (var i = 0; i < 6; i++)
+            if (split.Length == 1)
+            {
+                for (var i = 0; i < 6; i++)
+                {
+                    for (var j = 0; j < 12; j++)
+                    {
+                        yield return HandlePress(i);
+                        yield return new WaitForSeconds(0.3f);
+                        if (Canceller.ShouldCancel)
+                        {
+                            Canceller.ResetCancel();
+                            yield break;
+                        }
+                    }
+                    if (i < 5)
+                        yield return new WaitForSeconds(0.5f);
+                }
+            }
+            else if (DialPosNames.TryGetValue(split[1], out pos))
             {
                 for (var j = 0; j < 12; j++)
                 {
-                    yield return HandlePress(i);
+                    yield return HandlePress(pos);
                     yield return new WaitForSeconds(0.3f);
                     if (Canceller.ShouldCancel)
                     {
@@ -54,8 +72,6 @@ public class SafetySafeComponentSolver : ComponentSolver
                         yield break;
                     }
                 }
-                if(i < 5)
-                    yield return new WaitForSeconds(0.5f);
             }
         }
         else if (DialPosNames.TryGetValue(split[0], out pos))

--- a/Assets/Scripts/ComponentSolvers/Modded/Hexi/SimonStatesComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Hexi/SimonStatesComponentSolver.cs
@@ -72,7 +72,7 @@ public class SimonStatesComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/CryptographyComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/CryptographyComponentSolver.cs
@@ -38,7 +38,7 @@ public class CryptographyComponentSolver : ComponentSolver
                 DoInteractionStart(_buttons[keytext.IndexOf(y)]);
                 yield return new WaitForSeconds(0.1f);
                 DoInteractionEnd(_buttons[keytext.IndexOf(y)]);
-                if (StrikeCount != BeforeStrikes)
+                if (StrikeCount != BeforeStrikes || Solved)
                     yield break;
             }
         }

--- a/Assets/Scripts/ComponentSolvers/Modded/Perky/ListeningComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Modded/Perky/ListeningComponentSolver.cs
@@ -67,7 +67,7 @@ public class ListeningComponentSolver : ComponentSolver
                         DoInteractionStart(button);
                         yield return new WaitForSeconds(0.1f);
                         DoInteractionEnd(button);
-                        if (StrikeCount != beforeStrikes)
+                        if (StrikeCount != beforeStrikes || Solved)
                             yield break;
                     }
                     break;

--- a/Assets/Scripts/ComponentSolvers/Vanilla/InvisibleWallsComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Vanilla/InvisibleWallsComponentSolver.cs
@@ -63,7 +63,7 @@ public class InvisibleWallsComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Vanilla/KeypadComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Vanilla/KeypadComponentSolver.cs
@@ -52,7 +52,7 @@ public class KeypadComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Vanilla/SimonComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Vanilla/SimonComponentSolver.cs
@@ -61,7 +61,7 @@ public class SimonComponentSolver : ComponentSolver
                 DoInteractionEnd(button);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     break;
                 }

--- a/Assets/Scripts/ComponentSolvers/Vanilla/VennWireComponentSolver.cs
+++ b/Assets/Scripts/ComponentSolvers/Vanilla/VennWireComponentSolver.cs
@@ -52,7 +52,7 @@ public class VennWireComponentSolver : ComponentSolver
                 DoInteractionEnd(wire);
 
                 //Escape the sequence if a part of the given sequence is wrong
-                if (StrikeCount != beforeButtonStrikeCount)
+                if (StrikeCount != beforeButtonStrikeCount || Solved)
                 {
                     break;
                 }


### PR DESCRIPTION
Changes
* Modules can now infrom twitch chat as to what part of the command caused the strike with `strikemessage {message}`.
* Behaviour of `add strikes` and `award strikes` changed.  `add strikes` is more or less obsoleted by `multiple strikes`.
* Modules can now disable the built in strike awarding system on a temporary basis, so that they can award several strikes without flooding twitch chat.  This is done with `multiple strikes` to turn the strike tracker off.  Then with `award strikes {count}` to turn it back on AND award {count} strikes in one fell swoop.
* Safety safe now has a way to cycle just one dial.
* Needy quiz changed to correctly reflect the changed behaviour of `add strikes` / `award strikes` to the current behaviour of `multiple strikes` / `award strikes`.

Hopefully I won't be growing this PR massively while it awaits being pulled in.